### PR TITLE
Fixing main field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@aicore/linode-object-storage-lib",
   "version": "1.0.3",
   "description": "Javascript adapter package for linode object storage",
-  "main": "src/linode_object_storage_module.js",
+  "main": "./src/linode_object_storage_module.js",
   "scripts": {
     "eslint": "npm run lint",
     "eslint:fix": "npm run lint:fix",
@@ -42,5 +42,11 @@
     "eslint": "8.8.0",
     "husky": "7.0.4",
     "mocha": "9.2.0"
-  }
+  },
+  "keywords": [
+    "linode",
+    "object storage bucket",
+    "linode cli",
+    "linode bucket"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@aicore/linode-object-storage-lib",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Javascript adapter package for linode object storage",
-  "main": "index.js",
+  "main": "src/linode_object_storage_module.js",
   "scripts": {
     "eslint": "npm run lint",
     "eslint:fix": "npm run lint:fix",


### PR DESCRIPTION
### Changes
Modifying "main" field in package.json to fix the standard import statement,
`import linodeModule from '@aicore/linode-object-storage-lib';`

currently it's working only with 
`import linodeModule from '@aicore/linode-object-storage-lib/src/linode_object_storage_module.js';`

### Testing

No breaking changes
