### PR TITLE
Add support to override filenames of uploaded file in linode

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Request Parameters :
 * **region (type: String):** indicates the geographical server location (e.g us-east-1, eu-west-1a)
 * **file (type: String):** complete path of the file to be uploaded is passed on as a parameter
 * **bucket (type: String):** uniquely identifies the bucket where the file should be uploaded
+* **objectNameOverride (type: String):** Optional parameter, if given, the file name in wasabi will be overridden.
 
 Please refer to https://docs.aws.amazon.com/sdk-for-javascript/index.html for more details.
 
@@ -50,8 +51,11 @@ Please refer to https://docs.aws.amazon.com/sdk-for-javascript/index.html for mo
 import linodeModule from 'linode_object_storage_module';
 
 //Example for uploading file to linode object storage
-await linodeModule.uploadFileToLinodeBucket(accessKeyId, 
+const response = await linodeModule.uploadFileToLinodeBucket(accessKeyId, 
     secretAccessKey, region, file, bucket);
+
+//Example if you want to change the file name in linode/ provide suctom upload location
+const response = await linodeModule.uploadFileToBucket(accessKey, secretKey, region, fileName, bucketName, customPathInWasabi);
 ```
 
 ### Fetching Object URL

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Request Parameters :
 * **region (type: String):** indicates the geographical server location (e.g us-east-1, eu-west-1a)
 * **file (type: String):** complete path of the file to be uploaded is passed on as a parameter
 * **bucket (type: String):** uniquely identifies the bucket where the file should be uploaded
-* **objectNameOverride (type: String):** Optional parameter, if given, the file name in wasabi will be overridden.
+* **objectNameOverride (type: String):** Optional parameter, if given, the file name in linode will be overridden.
 
 Please refer to https://docs.aws.amazon.com/sdk-for-javascript/index.html for more details.
 
@@ -55,7 +55,7 @@ const response = await linodeModule.uploadFileToLinodeBucket(accessKeyId,
     secretAccessKey, region, file, bucket);
 
 //Example if you want to change the file name in linode/ provide suctom upload location
-const response = await linodeModule.uploadFileToBucket(accessKey, secretKey, region, fileName, bucketName, customPathInWasabi);
+const response = await linodeModule.uploadFileToBucket(accessKey, secretKey, region, fileName, bucketName, customPathInLinode);
 ```
 
 ### Fetching Object URL

--- a/src/aws_s3_client_module.js
+++ b/src/aws_s3_client_module.js
@@ -16,10 +16,12 @@ const {S3, Endpoint} = pkg;
  * @param filePath complete path of the filePath to be uploaded is passed on as a parameter
  * @param bucket uniquely identifies the bucket where the filePath should be uploaded
  * @param url suffix url to decide whether to upload the filePath to AWS S3 or LiNode Object Storage
+ * @param objectNameOverride If provided, the file will be uploaded with the given object name. Use this to provide
+ * custom file names and paths in s3.
  * @returns {Promise<void>}
  */
 
-async function uploadFileToBucket (accessKeyId, secretAccessKey, region, filePath, bucket, url) {
+async function uploadFileToBucket (accessKeyId, secretAccessKey, region, filePath, bucket, url, objectNameOverride) {
     const uploadStream = ({ Bucket, Key }) => {
         const s3Client = new S3({
             accessKeyId: accessKeyId,
@@ -34,8 +36,8 @@ async function uploadFileToBucket (accessKeyId, secretAccessKey, region, filePat
             promise: s3Client.upload({ Bucket, Key, Body: pass }).promise()
         };
     };
-    const fileName = path.basename(filePath);
-    const { writeStream, promise } = uploadStream({Bucket: bucket, Key: fileName});
+    const objectName = objectNameOverride ? objectNameOverride : path.basename(filePath);
+    const { writeStream, promise } = uploadStream({Bucket: bucket, Key: objectName});
     fsExtra.createReadStream(filePath).pipe(writeStream);
     await promise;
 }

--- a/src/linode_object_storage_module.js
+++ b/src/linode_object_storage_module.js
@@ -13,16 +13,18 @@ const BASE_LINODE_OBJECT_URL = 'https://api.linode.com/v4/object-storage/buckets
  * @param region indicates the geographical server location (e.g us-east-1, eu-west-1a)
  * @param file complete path of the file to be uploaded is passed on as a parameter
  * @param bucket uniquely identifies the bucket where the file should be uploaded
+ * @param objectNameOverride If provided, the file will be uploaded with the given object name. Use this to provide
+ * custom file names and paths in linode.
  * @returns {Promise<void>}
  */
-async function uploadFileToLinodeBucket (accessKeyId, secretAccessKey, region, file, bucket) {
+async function uploadFileToLinodeBucket (accessKeyId, secretAccessKey, region, file, bucket, objectNameOverride) {
     if (!accessKeyId || !secretAccessKey || !region || !file || !bucket) {
         throw new Error("Invalid parameter value: accessKeyId, secretAccessKey, region, filePath " +
         "and bucketName are required parameters");
     }
 
     await uploadFileToBucket(accessKeyId,
-        secretAccessKey, region, file, bucket, BASE_LINODE_URL_SUFFIX);
+        secretAccessKey, region, file, bucket, BASE_LINODE_URL_SUFFIX, objectNameOverride);
     console.log("File: " + file + " uploaded successfully to Bucket: " + bucket);
 }
 
@@ -37,7 +39,7 @@ async function uploadFileToLinodeBucket (accessKeyId, secretAccessKey, region, f
  * @param accessToken Linode API Key.
  * @param region indicates the geographical server location (e.g us-east-1, eu-west-1a)
  * @param bucketName Exact Name of the bucket the file resides in
- * @param objectName Exact Name of the the file
+ * @param objectName Exact Name of the file
  * @returns {Promise<*>} File URL using which the file can be downloaded.
  */
 async function fetchObjectUrl (accessToken, region, bucketName, objectName) {


### PR DESCRIPTION
Add support to override filenames of uploaded file in linode
```js
//Example if you want to change the file name in linode/ provide suctom upload location
const response = await linodeModule.uploadFileToBucket(accessKey, secretKey, region, fileName, bucketName, customPathInWasabi);
```